### PR TITLE
Added /skills endpoints and relationship endpoints for skills under /…

### DIFF
--- a/job-tracker-backend/models/contact.js
+++ b/job-tracker-backend/models/contact.js
@@ -1,4 +1,4 @@
-const psPool = require('../psPool')
+const psPool = require('../utils/psPool')
 const { UnauthorizedError, BadRequestError } = require('../utils/errors')
 
 

--- a/job-tracker-backend/routes/skills.js
+++ b/job-tracker-backend/routes/skills.js
@@ -1,0 +1,101 @@
+const psPool = require('../utils/psPool')
+
+module.exports = function(app) {
+    //Description: Returns all skills for user as an array
+    app.get('/skills', function (req, res) {
+        psPool.connect((err, client, done) => {
+            let query = {
+                text: 'SELECT * FROM skill WHERE "userId" = $1',
+                values: [req.userId]
+            }
+    
+            client.query(query, (err, ps_res) => {
+                done();
+    
+                if (err ) {
+                    console.log(err.stack);
+                    res.sendStatus(400);
+                } else {
+                    res.status(200).json(ps_res.rows);
+                }
+            })
+        })
+    });
+    
+    /*  
+        Description: Adds a new skill entity to the database
+        Example Body (JSON):
+        {
+            "skillName": "PostgreSQL",
+            "comfortLevel": 100
+        }
+    */
+    app.post('/skills', function (req, res) {
+        psPool.connect((err, client, done) => {
+            let query = {
+                text: 'INSERT INTO skill("userId", "skillname", "comfortlevel") VALUES($1, $2, $3) RETURNING *',
+                values: [req.userId, req.body.skillName, req.body.comfortLevel]
+            }
+    
+            client.query(query, (err, ps_res) => {
+                done();
+    
+                if (err) {
+                    console.log(err.stack);
+                    res.sendStatus(400);
+                } else {
+                    res.status(201).json(ps_res.rows[0]);
+                }
+            })
+        })
+    });
+    
+    /*  
+        Description: Updates a skill entity already existing in the database
+        Example Body (JSON):
+        {
+            "skillName: "postgresSQL",
+            "comfortLevel": 0
+        }
+    */
+    app.put('/skills/:skill_id', function (req, res) {
+        psPool.connect((err, client, done) => {
+            let query = {
+                text: 'UPDATE skill SET skillname = $2, comfortlevel = $3 WHERE ("userId" = $1 AND skillid = $4) RETURNING *',
+                values: [req.userId, req.body.skillName, req.body.comfortLevel, req.params.skill_id]
+            }
+    
+            client.query(query, (err, ps_res) => {
+                done();
+    
+                if (err) {
+                    console.log(err.stack);
+                    res.sendStatus(400);
+                } else {
+                    res.status(200).json(ps_res.rows[0]);
+                }
+            })
+        })
+    });
+    
+    //Description: Deletes a skill based on the skill_id defined as a URL parameter
+    app.delete('/skills/:skill_id', function (req, res) {
+        psPool.connect((err, client, done) => {
+            let query = {
+                text: 'DELETE FROM skill WHERE ("userId" = $1 AND skillid = $2)',
+                values: [req.userId, req.params.skill_id]
+            }
+    
+            client.query(query, (err, ps_res) => {
+                done();
+    
+                if (err) {
+                    console.log(err.stack);
+                    res.sendStatus(400);
+                } else {
+                    res.sendStatus(204);
+                }
+            })
+        })
+    });
+}

--- a/job-tracker-backend/server.js
+++ b/job-tracker-backend/server.js
@@ -87,6 +87,9 @@ app.use(express.json());
 //Creates GET, POST, PUT and DELETE endpoints for /jobs
 require('./routes/jobs')(app);
 
+//Creates GET, POST, PUT and DELETE endpoints for /skills
+require('./routes/skills')(app);
+
 // If no routes are touched then we will get a 404 error
 app.use((req, res, next) => {
     return next(new NotFoundError())


### PR DESCRIPTION
Added endpoints for /skills (GET, POST, PUT, DELETE). 

In addition, created two _additional_ endpoints under /jobs to build a many-to-many relationship to /skills. This includes:
- POST /jobs/<job_id>/skills/<skill_id> (Adds a new skill to a job)
- DELETE /jobs/<job_id>/skills/<skill_id> (Removes a skill from a job)

Finally, GET /jobs has a much broader scope and will return any associated contacts or skills as nested arrays under the "contacts" and "skills" properties.